### PR TITLE
Fix TypeError when collapse element is unmounted before transition completes

### DIFF
--- a/packages/vue-collapsed/src/Collapse.vue
+++ b/packages/vue-collapsed/src/Collapse.vue
@@ -168,12 +168,13 @@ watch(isExpanded, (isExpanding) => {
       })
 
       requestAnimationFrame(() => {
+         if (!collapseRef.value) return
          /** If for any unknown edge case the scrollHeight === 0, abort transition and force expand */
-         if (collapseRef.value!.scrollHeight === 0) return onExpanded()
+         if (collapseRef.value.scrollHeight === 0) return onExpanded()
 
          /** Set height to scrollHeight and trigger the transition. */
 
-         transitionStartScrollHeight = collapseRef.value!.scrollHeight
+         transitionStartScrollHeight = collapseRef.value.scrollHeight
 
          addStyles({
             ...getTransitionProp(collapseRef),
@@ -203,6 +204,7 @@ watch(isExpanded, (isExpanding) => {
       if (collapseRef.value.scrollHeight === 0) return onCollapsed()
 
       requestAnimationFrame(() => {
+         if (!collapseRef.value) return
          /** Set height to baseHeight and trigger the transition. */
          addStyles({
             ...baseHeightStyles.value,
@@ -228,6 +230,8 @@ watch(baseHeight, (newBaseHeight) => {
 // Transition events
 
 function onTransitionEnd(e: TransitionEvent) {
+   if (!collapseRef.value) return
+
    if (e.target && e.target === collapseRef.value && e.propertyName === 'height') {
       /**
        * Reset styles to the initial style state,


### PR DESCRIPTION
This PR fixes a race condition where the internal collapse element ref can become null between scheduling a requestAnimationFrame and its execution, or between starting a transition and receiving the transitionend event.
When this happens, the current implementation tries to access scrollHeight on a null element and throws:

TypeError: Cannot read properties of null (reading 'scrollHeight')

The fix adds null checks for collapseRef in the requestAnimationFrame callbacks and in the transitionend handler. If the element has been unmounted, the callbacks now bail out early, preserving the existing behavior without throwing.

Screenshots from Sentry:
<img width="1399" height="409" alt="image" src="https://github.com/user-attachments/assets/be5f3f93-7187-4a73-a174-59516b6f7922" />
<img width="257" height="119" alt="image" src="https://github.com/user-attachments/assets/355a56c5-a214-424c-98b8-89b1b2815d2f" />

Lines caused error in our app:
<img width="676" height="164" alt="image" src="https://github.com/user-attachments/assets/827038af-dd31-4394-a253-8affe4ce1ca6" />
